### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server that provides integration with Jira's REST API, allowing AI assistants to manage Jira issues programmatically.
 
+<a href="https://glama.ai/mcp/servers/2a6ts4367i"><img width="380" height="200" src="https://glama.ai/mcp/servers/2a6ts4367i/badge" alt="mcp-jira-server MCP server" /></a>
+
 ## Features
 
 This server provides tools for managing Jira issues:


### PR DESCRIPTION
This PR adds a badge for the mcp-jira-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/2a6ts4367i"><img width="380" height="200" src="https://glama.ai/mcp/servers/2a6ts4367i/badge" alt="mcp-jira-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.